### PR TITLE
Dockerfileにbundle installを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,8 @@ COPY ./entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT [ "entrypoint.sh" ]
 
+COPY ./Gemfile $APP_ROOT
+COPY ./Gemfile.lock $APP_ROOT
+RUN bundle install
+
 CMD [ "bundle", "exec", "rails", "s", "-b", "0.0.0.0" ]


### PR DESCRIPTION
## 経緯

volumesに何もない状態(初期状態)でdocker-composeを起動したところ、以下が発生した。

```sh
% docker-compose up
WARNING: Found orphan containers (dbc-s8-ruby_db_1) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
Starting dbc-s8-ruby_app_1 ... done
Attaching to dbc-s8-ruby_app_1
app_1  | bundler: command not found: rails
app_1  | Install missing gem executables with `bundle install`
```

## 対策

`rails s` より前に `bundle install` が実行されるようにする。

## 懸念点

- Gemfileが変更された場合は変わらずエラーなので、、そもそもL9のRails sを消す方向で検討してもいいのかもしれない。
- vscodeのremote containerを使用している場合は困らないらしい。

(今度口頭で相談ささてください)