### PR TITLE
DevContainer用にコードジャンプ・リファレンス表示を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
   "extensions": [
     "rebornix.ruby",
     "misogi.ruby-rubocop",
-    "ms-vsliveshare.vsliveshare"
+    "ms-vsliveshare.vsliveshare",
+    "castwide.solargraph"
   ]
 }


### PR DESCRIPTION
タイトル通り
Codespaces起動時に、solargraphのgemをインストールする旨のダイアログが右下に出現するので、 `Install` をクリックすれば使用できます