### PR TITLE
Remote Containerに特化したDocker設定へ変更

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.7.4
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+      vim && \
+    apt-get clean -y
+
+RUN gem install bundler solargraph ruby-debug-ide
+
+WORKDIR /app_root
+COPY . .
+RUN bundle install --jobs=$(nproc)
+
+COPY ./entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT [ "entrypoint.sh" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,15 @@
 {
   "name": "dbc-s8-ruby",
-  "dockerComposeFile": "../docker-compose.yml",
+  "dockerComposeFile": "./docker-compose.yml",
   "overrideCommand": true,
   "service": "app",
   "workspaceFolder": "/app_root",
   "settings": {
     "ruby.useBundler": true,
-    "ruby.useLanguageServer": true,
-    "ruby.rubocop.suppressRubocopWarnings": true
-},
+    "ruby.useLanguageServer": true
+  },
   "extensions": [
     "rebornix.ruby",
-    "misogi.ruby-rubocop",
     "ms-vsliveshare.vsliveshare",
-    "castwide.solargraph"
   ]
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,18 +2,17 @@ version: '3'
 
 services:
   app:
-    build: .
+    build:
+      context: ../
+      dockerfile: ./.devcontainer/Dockerfile
     environment:
       BINDING: 0.0.0.0
     volumes:
-      - .:/app_root:delegated
+      - app_volume:/app_root
       - app_bundle:/usr/local/bundle
-      - app_logs:/app_root/log
-      - app_tmp:/app_root/tmp
     ports:
       - 3000:3000
 
 volumes:
+  app_volume:
   app_bundle:
-  app_logs:
-  app_tmp:

--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,6 @@
 
 # Ignore VSCode settings.
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "misogi.ruby-rubocop",
+    "castwide.solargraph",
+    "eamodio.gitlens"
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM ruby:2.7.4
-
-WORKDIR /app_root
-
-COPY ./entrypoint.sh /usr/bin/
-RUN chmod +x /usr/bin/entrypoint.sh
-ENTRYPOINT [ "entrypoint.sh" ]
-
-CMD [ "bundle", "exec", "rails", "s", "-b", "0.0.0.0" ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+## 環境構築
+
+### ケース1 Codespacesをブラウザ上で利用する場合
+
+Codespacesの利用権限がない場合、誰かに聞いてみてください
+
+1. https://github.com/wyrd-team/dbc-s8-ruby から、code > codespaces > New Codespace > 4 core > Create Codespace
+2. `$ bin/setup`
+
+2回目以降は、code > codespaces > 開きたいCodespace
+
+### ケース2 CodespacesをVSCodeから利用する場合
+
+Codespacesの利用権限がない場合、誰かに聞いてみてください
+
+1. https://github.com/wyrd-team/dbc-s8-ruby から、code > codespaces > New Codespace > 4 core > Create Codespace
+2. 画面下に出現する Open This Codespace In VScode Desktop をクリックし、VSCodeが立ち上がるので、ブラウザのCodespacesはタブを閉じる
+3. `$ bin/setup`
+
+2回目以降は、VSCodeのようこそ画面から選択・起動できる
+
+### ケース3 ローカルでRemote Containerを立ち上げる場合
+
+1. VSCodeにVSCode Remoteプラグインをインストール
+2. Reopen in Container
+3. `$ bin/setup`


### PR DESCRIPTION
互換性を捨てることで、プラグインの選択や事前のインストールを可能にする
以降、docker-composeコマンドは利用できなくなります